### PR TITLE
Autogenerate python dojo folders with a cron job

### DIFF
--- a/.github/workflows/weekly-setup.yaml
+++ b/.github/workflows/weekly-setup.yaml
@@ -1,0 +1,47 @@
+name: "Create Python Dojo Folders"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "40 15 * * WED"
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: write
+
+jobs:
+  setup:
+    name: weekly setup
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Check if it's the second week
+      run: |
+        week_mod=$(( ( ($(date +%s) - $(date +%s -d 20240918)) / 604800 ) % 2 ))
+        echo "week_mod=$week_mod" >> "$GITHUB_ENV"
+
+    - name: Create Folders
+      if: ${{ github.event_name == 'workflow_dispatch' || env.week_mod == '0' }}
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        
+        folder_name=$(date +"%Y-%b-%d")
+        
+        if ! [ -d "$folder_name" ]; then
+          mkdir -p "$folder_name/Group-1"
+          mkdir -p "$folder_name/Group-2"
+          touch "$folder_name/Group-1/main.py"
+          touch "$folder_name/Group-2/main.py"
+  
+          git add "$folder_name"
+          git commit -m "create python dojo folder for $folder_name"
+          git push
+        else
+          echo "Python dojo folder has already been created for this week, no commit made"
+        fi


### PR DESCRIPTION
## Description

Adds a github workflow to automatically create the Group 1 & 2 folders for Python Dojo every other wednesday

### Detail

Unfortunately there doesn't seem to be any way to set a cron job to run 'every other' week, 
so I conditioned it on being an even number of weeks since the last session instead

Addtionally these seem to not always run when they're scheduled to (and sometimes not at all) - the [scheduling docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule) 
mention that during high load jobs may be delayed or cancelled entirely, so I've set this to run off the hour at 3.40pm UTC and included the option for us to trigger it manually
